### PR TITLE
Discarding the master-slave phrasing

### DIFF
--- a/mymensor/mymviews.py
+++ b/mymensor/mymviews.py
@@ -990,8 +990,8 @@ def cognitoauth(request):
             usernameprefix = username[:7]
             username = username.replace(usernameprefix, '')
             usergroup = 'mymARmobileapp'
-            masteruser = User.objects.get(username=username)
-            assetinstance = Asset.objects.get(assetOwner=masteruser)
+            mainuser = User.objects.get(username=username)
+            assetinstance = Asset.objects.get(assetOwner=mainuser)
 
         subscriptionState = subscription_state(assetinstance)
 


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.